### PR TITLE
Remove query string display line

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,11 +37,6 @@
               <p>The Azure Content Delivery Network (CDN) caches static web content at strategically placed locations to provide maximum throughput for delivering content to users. The CDN offers developers a global solution for delivering high-bandwidth content by caching the content at physical nodes across the world.</p>
           </div>
       </div>
-        <h2 id="footer">
-            <script>
-                document.getElementById("footer").innerHTML = "Query string:  " + window.location.search;
-            </script>
-        </h2>
     </div>
 
     <!-- Bootstrap core JavaScript


### PR DESCRIPTION
Removing the query string display code -- was going to use it for versioning section of CDN tutorial, but this method won't work for demonstrating query string versioning options.